### PR TITLE
Fetch topic metadata

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -5,9 +5,7 @@ const adminController = {};
 adminController.getTopics = async (req, res, next) => {
   try {
     const arrayOfTopics = await admin.listTopics();
-    console.log('Array of Topics', arrayOfTopics);
     res.locals.topics = [...arrayOfTopics];
-    console.log('res.locals.topics');
     return next();
   } catch (err) {
     console.log(err);
@@ -40,7 +38,6 @@ adminController.getBrokerInfo = async (req, res, next) => {
   try {
     const brokerInfo = await admin.describeCluster();
     res.locals.brokerInfo = brokerInfo.brokers;
-    console.log('res locals', res.locals.brokerInfo);
     return next();
   } catch (err) {
     console.log(err);

--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -26,7 +26,16 @@ adminController.getPartitions = async (req, res, next) => {
   }
 };
 
-//
+adminController.getTopicOffsets = async (req, res, next) => {
+  try {
+    const topicOffsets = await admin.fetchTopicOffsets(`${req.params.topic}`);
+    res.locals.offsets = topicOffsets;
+    return next();
+  } catch (err) {
+    console.log(err);
+  }
+};
+
 adminController.getBrokerInfo = async (req, res, next) => {
   try {
     const brokerInfo = await admin.describeCluster();

--- a/server/routes/adminRouter.js
+++ b/server/routes/adminRouter.js
@@ -8,9 +8,13 @@ router.get('/topics', adminController.getTopics, (req, res) =>
   res.status(200).json([...res.locals.topics])
 );
 
-//sends an array of patitions. Each element in the array is an object. "partitionId" is the key that gives you the partition ID. "replicas" is the key that gives you an array of replica assignments.
-router.get('/partitionInfo/:topic', adminController.getPartitions, (req, res) =>
-  res.status(200).json(res.locals.partitions)
+//sends an array of partitions. Each element in the array is an object. "partitionId" is the key that gives you the partition ID. "replicas" is the key that gives you an array of replica assignments.
+//sends an array of partition objects, with most recent offset information 'high' and earliest offset positionb 'low'
+router.get(
+  '/partitionInfo/:topic',
+  adminController.getPartitions,
+  adminController.getTopicOffsets,
+  (req, res) => res.status(200).json(res.locals)
 );
 
 //sends an array of brokers. Each element in the array in an object. "nodeId" is the key that gives you the broker number.

--- a/server/routes/adminRouter.js
+++ b/server/routes/adminRouter.js
@@ -8,8 +8,9 @@ router.get('/topics', adminController.getTopics, (req, res) =>
   res.status(200).json([...res.locals.topics])
 );
 
-//sends an array of partitions. Each element in the array is an object. "partitionId" is the key that gives you the partition ID. "replicas" is the key that gives you an array of replica assignments.
-//sends an array of partition objects, with most recent offset information 'high' and earliest offset positionb 'low'
+//send an object with two keys. "partitions" holds the array of partitions. "offsets" holds the array of offsets.
+//each element in the partition array is an object. "partitionId" is the key that gives you the partition ID. "replicas" is the key that gives you an array of replica assignments.
+//each element in the offset array is an object, with most recent offset information 'high' and earliest offset position 'low'
 router.get(
   '/partitionInfo/:topic',
   adminController.getPartitions,


### PR DESCRIPTION
Created controller function to fetch topic offsets by partition.
Updated admin router to hit this piece of middleware and store the data on res.locals before returning a response to the client.

Data is returned in an array: [ { partition: 0, offset: '21', high: '21', low: '0' } ]

An offset is a certain point in the partition log. When a consumer consumes a message, it 'commits' said message. This tells the Kafka broker that the consumer group has consumed the message.
