### PR TITLE
Cris options menu

### DIFF
--- a/client/components/AuxiliaryMetrics.jsx
+++ b/client/components/AuxiliaryMetrics.jsx
@@ -20,11 +20,13 @@ const AuxiliaryMetrics = ({
       chartOptions[keyID] = MetricsOptions.default;
     else chartOptions[keyID] = MetricsOptions[keyID];
     graphs.push(
+      <li key={keyID}>
       <LineGraphMetrics
         chartOptions={chartOptions[keyID]}
         chartLabel={keyID}
         metricData={metrics[key]}
       />
+      </li>
     );
   });
 
@@ -53,7 +55,9 @@ const AuxiliaryMetrics = ({
   return (
     <div>
       {button}
-      {graphs}
+      <ul>
+        {graphs}
+      </ul>
     </div>
   );
 };

--- a/client/components/LineGraphMetrics.jsx
+++ b/client/components/LineGraphMetrics.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Line } from 'react-chartjs-2';
 
 const LineGraphMetrics = ({ metricData, chartOptions, chartLabel }) => {
-  const { bkgdColor, brdrColor, labelsArray, titleObj, chartHeight } = chartOptions;
+  const { bkgdColor, brdrColor, labelsArray, titleObj, yConfig } = chartOptions;
   const [data, setData] = useState();
   console.log(metricData);
 
@@ -34,17 +34,10 @@ const LineGraphMetrics = ({ metricData, chartOptions, chartLabel }) => {
   }
 
   const options = {
-    responsive: true,
     maintainAspectRatio: false,
     title: titleObj,
     scales: {
-      yAxes: [
-        {
-          ticks: {
-            beginAtZero: false,
-          },
-        },
-      ],
+      yAxes: yConfig,
     },
   };
 
@@ -63,7 +56,7 @@ const LineGraphMetrics = ({ metricData, chartOptions, chartLabel }) => {
     <div>
       <Line
         data={data}
-        height={chartHeight}
+        height={375}
         options={options}
         ref={(reference) => (chartRef = reference)}
       />

--- a/client/components/MetricsOptions.jsx
+++ b/client/components/MetricsOptions.jsx
@@ -2,147 +2,275 @@ import React from 'react';
 
 const MetricsOptions = {
   default: {
-    
-    bkgdColor: 'rgba(75,192,192,0.2)',
-    brdrColor: 'rgba(75,192,192,1)',
+    bkgdColor: 'rgba(121,134,203,0.2)',
+    brdrColor: 'rgba(121,134,203,1)',
     labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
     titleObj: {
       display: false,
-      text: ''
+      text: '',
     },
-    chartHeight: 250
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: false,
+          labelString: 'Test Axis Label'
+        }
+      }
+    ]
   },
   disk_write_bytes: {
-    bkgdColor: 'rgba(186,104,200,1)', //same purple[300] from MetricsContainer
-    brdrColor: 'rgba(186,104,200,1)',
+    bkgdColor: 'rgba(121,134,203,0.3)',
+    brdrColor: 'rgba(121,134,203,1)',
     labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
     titleObj: {
       display: true,
-      text: 'Disk Write Bytes'
+      text: 'Disk Usage: Write',
     },
-    chartHeight: 500
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'bytes',
+        }
+      },
+    ]
   },
   cpu_seconds_total: {
-    bkgdColor: 'rgba(229,115,115,0.2)', //same red[300] from MetricsContainer
+    bkgdColor: 'rgba(229,115,115,0.3)',
     brdrColor: 'rgba(229,115,115,1)',
     labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
     titleObj: {
       display: true,
-      text: 'CPU Seconds Total'
+      text: 'CPU Seconds Total',
     },
-    chartHeight: 500
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'seconds',
+        }
+      },
+    ]
   },
-
   disk_read_bytes: {
-    bkgdColor: 'rgba(240,98,146,0.2)', //same pink[300] from MetricsContainer
+    bkgdColor: 'rgba(240,98,146,0.3)',
     brdrColor: 'rgba(240,98,146,1)',
     labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
     titleObj: {
       display: true,
-      text: 'Disk Read Bytes'
+      text: 'Disk Usage: Read',
     },
-    chartHeight: 500
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'bytes',
+        }
+      },
+    ]
   },
 
-  // brokertopicmetrics_bytesin_total: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
+  brokertopicmetrics_bytesin_total: {
+    bkgdColor: 'rgba(186,104,200,0.3)',
+    brdrColor: 'rgba(186,104,200,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Broker Topic: Total Bytes in',
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'bytes',
+        }
+      },
+    ]
+  },
+  brokertopicmetrics_bytesout_total: {
+    bkgdColor: 'rgba(121,134,203,0.2)',
+    brdrColor: 'rgba(121,134,203,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Broker Topic: Total Bytes Out',
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'bytes',
+        }
+      },
+    ]
+  },
+  leaderelectionrateandtimems_count: {
+    bkgdColor: 'rgba(229,115,115,0.2)',
+    brdrColor: 'rgba(229,115,115,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Leader Election Rate',
+      
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'election rate',
+        }
+      },
+    ]
+  },
+  globalpartitioncount: {
+    bkgdColor: 'rgba(240,98,146,0.2)',
+    brdrColor: 'rgba(240,98,146,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Global Partitions',
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of partitions',
+        }
+      },
+    ]
+  },
 
-  // brokertopicmetrics_bytesout_total: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
+  'purgatorysize{delayedOperation="Produce",}': {
+    bkgdColor: 'rgba(186,104,200,0.2)',
+    brdrColor: 'rgba(186,104,200,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Producer Request Purgatory',
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of producer requests',
+        }
+      },
+    ]
+  },
+  'purgatorysize{delayedOperation="Fetch",}': {
+    bkgdColor: 'rgba(121,134,203,0.4)',
+    brdrColor: 'rgba(121,134,203,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Fetch Request Purgatory',
+      
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of fetch requests',
+        }
+      },
+    ]
+  },
 
-  // leaderelectionrateandtimems_count: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
+  isrshrinks_total: {
+    bkgdColor: 'rgba(229,115,115,0.4)',
+    brdrColor: 'rgba(229,115,115,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'In-Sync Replicas: Shrinks',
+      
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of replicas',
+        }
+      },
+    ]
+  },
 
-  // globalpartitioncount: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
+  isrexpands_total: {
+    bkgdColor: 'rgba(240,98,146,0.4)',
+    brdrColor: 'rgba(240,98,146,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'In-Sync Replicas: Expands',
+      
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of replicas',
+        }
+      },
+    ]
+  },
 
-  // 'purgatorysize{delayedOperation="Produce",}': {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
-
-  // 'purgatorysize{delayedOperation="Fetch",}': {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
-
-  // isrshrinks_total: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
-
-  // isrexpands_total: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
-
-  // brokertopicmetrics_totalproducerequests_total: {
-  //   bkgdColor: 'rgba(186,104,200,0.2)', //same purple[300] from MetricsContainer
-  //   brdrColor: 'rgba(186,104,200,1)',
-  //   labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
-  //   titleObj: {
-  //     display: true,
-  //     text: 'Disk Write Bytes'
-  //   },
-  //   chartHeight: 500
-  // },
-
+  brokertopicmetrics_totalproducerequests_total: {
+    bkgdColor: 'rgba(186,104,200,0.4)',
+    brdrColor: 'rgba(186,104,200,1)',
+    labelsArray: ['10 secs ago', '9 secs ago', '8 secs ago', '7 secs ago', '6 secs ago', '5 secs ago', '4 secs ago', '3 secs ago', '2 secs ago', '1 sec ago', 'Currently'],
+    titleObj: {
+      display: true,
+      text: 'Broker Topic: Total Producer Requests',
+      
+    },
+    yConfig: [
+      {
+        ticks: {
+          beginAtZero: false,
+        },
+        scaleLabel: {
+          display: true,
+          labelString: '# of requests',
+        }
+      },
+    ]
+  },
 }
 
 


### PR DESCRIPTION
MergeOptions object now populated for all current metrics, with color variation, title, and Y-axis label all added. 
*Note: chart width removed as it cannot currently be set at the chart level. width being set by material ui components at top of screen. conflict may have been cause of error. Line graphs now pushed to 'graphs' as list items and graphs is rendered as an unordered list. the list item key is the repurposed keyID matching the metric name for reference in any further attempts to stype size or background.
